### PR TITLE
Extend Landscape 19.10 support to April 2022

### DIFF
--- a/en/onprem.md
+++ b/en/onprem.md
@@ -7,7 +7,7 @@ Each major Landscape version is supported for a period of one year after release
 
 | **major version**                | **Release date** | **Supported until** | **Version of Ubuntu**  |
 | ----------------------           | ---------------- | ------------------- | ---------------------  |
-| [19.10](./ReleaseNotes19.10.md)  | 2019-Oct         | **2021-Oct**        | 18.04 LTS              |
+| [19.10](./ReleaseNotes19.10.md)  | 2019-Oct         | **2022-Apr**        | 18.04 LTS              |
 
 !!! Note:
     Work is being done to allow Landscape On-Premises to run on Ubuntu 20.04. However, there is currently no ETA for that support. Once Ubuntu 20.04 is supported, Landscape On-Premises will still continue to be supported on Ubuntu 18.04 until there has been sufficient time for customers to migrate their environment.


### PR DESCRIPTION
As there is not currently an ETA for the next version of Landscape, lets go ahead and extend the support for the current release.