### PR TITLE
Recommend disabling apache mod-status.

### DIFF
--- a/en/ReleaseNotes19.10.md
+++ b/en/ReleaseNotes19.10.md
@@ -105,6 +105,11 @@ Update the Landscape apache vhost as follows, adding the following SSL directive
   SSLCipherSuite EECDH+AESGCM+AES128:EDH+AESGCM+AES128:EECDH+AES128:EDH+AES128:ECDH+AESGCM+AES128:aRSA+AESGCM+AES128:ECDH+AES128:DH+AES128:aRSA+AES128:EECDH+AESGCM:EDH+AESGCM:EECDH:EDH:ECDH+AESGCM:aRSA+AESGCM:ECDH:DH:aRSA:HIGH:!MEDIUM:!aNULL:!NULL:!LOW:!3DES:!DSS:!EXP:!PSK:!SRP:!CAMELLIA:!DHE-RSA-AES128-SHA:!DHE-RSA-AES256-SHA:!aECDH
 ```
 
+Unless you require it and take necessary steps to secure that endpoint, it is recommended to disable mod-status:
+```
+sudo a2dismod status
+```
+
 Restart apache
 ```
 sudo service apache2 restart

--- a/en/landscape-install-manual.md
+++ b/en/landscape-install-manual.md
@@ -285,7 +285,6 @@ If you are using a custom certificate authority for your SSL certificate, then y
 
     RewriteRule ^/ping$ http://localhost:8070/ping [P]
 
-    RewriteCond %{REQUEST_URI} !^/server-status
     RewriteCond %{REQUEST_URI} !^/icons
     RewriteCond %{REQUEST_URI} !^/static/
     RewriteCond %{REQUEST_URI} !^/offline/
@@ -425,6 +424,10 @@ If you are using a custom certificate authority for your SSL certificate, then y
 We now need to enable some modules:
 ```
 for module in rewrite proxy_http ssl headers expires; do sudo a2enmod $module; done
+```
+Unless you require it and take necessary steps to secure that endpoint, it is recommended to disable mod-status:
+```
+sudo a2dismod status
 ```
 Disable the default http vhost:
 ```


### PR DESCRIPTION
Recommend disabling apache mod_status in installation instructions, unless secured. (lp:1929037)
