### PR TITLE
Document current and optional maintenance scripts

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -51,7 +51,7 @@ navigation:
       - title: External Authentication
         location: onprem-auth.md
 
-      - title: Maintenance tasks
+      - title: Maintenance Tasks
         location: onprem-maintenance.md
 
   - title: API

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -51,6 +51,9 @@ navigation:
       - title: External Authentication
         location: onprem-auth.md
 
+      - title: Maintenance tasks
+        location: onprem-maintenance.md
+
   - title: API
     location: api.md
 

--- a/en/onprem-maintenance.md
+++ b/en/onprem-maintenance.md
@@ -1,4 +1,4 @@
-Title: Daily maintenance
+Title: Maintenance Tasks
 
 # Recurrent tasks and maintenance
 

--- a/en/onprem-maintenance.md
+++ b/en/onprem-maintenance.md
@@ -1,0 +1,57 @@
+Title: Daily maintenance
+
+# Recurrent tasks and maintenance
+
+Landscape Server installs a few scheduled tasks, defined in the `/etc/cron.d/landscape-server` file.
+
+* `/opt/canonical/landscape/scripts/maintenance.sh`
+    - This task does the daily maintenance of adding monitoring graphs tables and deleting older data. Failure to run this task for multiple days prevents monitoring data from being stored, and will lead to gaps in the graphs.
+* `/opt/canonical/landscape/scripts/update_security_db.sh`
+    - This task loads new USN/CVE data. This is required for identifying which updates are "security updates".
+* `( /opt/canonical/landscape/scripts/update_alerts.sh; /opt/canonical/landscape/scripts/landscape_profiles.sh; /opt/canonical/landscape/scripts/process_alerts.sh )`
+    - This set of tasks processes alerts and applies profiles. Part of the Landscape functionalities depends on checking conditions at frequent intervals. This includes offline alerts, and package profile compliance.
+* `/opt/canonical/landscape/scripts/hash_id_databases.sh`
+    - This tasks regenerates packages hash-ids mapping files. Those hash-id files are what helps for newly registered computers to report their installed and available packages quickly. Out-of-date hash-id files causes computers to report their package at a slower rate (500 packages at a time).
+* `/opt/canonical/landscape/scripts/meta_releases.sh`
+    - This task checks for new releases of Ubuntu.
+* `/opt/canonical/landscape/scripts/sync_lds_releases.sh`
+    - This task verifies if there are new Landscape Server upgrades available in order to add a notification on the account page.
+* `/opt/canonical/landscape/scripts/report_anonymous_metrics.sh`
+    - This task reports some anonymous metrics, such as the installed Landscape Server version.
+
+
+## Optional Cleaning of Activity History
+
+Landscape already includes maintenance tasks to limit monitoring graphs history, as mentioned above.
+Extra maintenance jobs can also be scheduled to limit old activities and old events to a retention period. For example, create a `/etc/cron.d/ls_maintenance` file and add the following:
+
+```
+0 3 * * * landscape /opt/canonical/landscape/cleanup-activities 90
+30 3 * * * landscape /opt/canonical/landscape/cleanup-events 90
+```
+
+This will schedule 2 tasks:
+
+- A cleanup of finished activities older than 90 days. Runs every day at 3:00.
+- A cleanup of events older than 90 days. Runs every day at 3:30.
+
+Those tools will log their output to syslog. This can be inspected by running
+
+```
+journalctl -t cleanup-activities -t cleanup-events
+```
+
+The result of those tasks can also be logged to separate files, much like other Landscape services. To do that, edit the `/etc/rsyslog.d/20-landscape.conf` file and add the following lines to the end:
+
+```
+if $programname == 'cleanup-activities' then /var/log/landscape-server/cleanup-activities.log;Landscape
+& ~
+if $programname == 'cleanup-events' then /var/log/landscape-server/cleanup-events.log;Landscape
+& ~
+```
+
+Then restart the logging service by running:
+
+```
+sudo systemctl restart rsyslog.service
+```


### PR DESCRIPTION
Add a page for onprem maintenance/recurrent tasks.

* Hopefully gives some insight of why some features might not work when the related task is not running.
* Document the extra maintenance scripts and how to set them up.
